### PR TITLE
chore: remove codecov integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,33 +35,11 @@ jobs:
       - uses: actions/checkout@master
       - name: tidy
         run: make tidy
-  codecov:
-    # golandci-lint need to be run before codecov and succeed
-    needs: [tidy]
-    name: Code Coverage
-    if: github.repository == 'meshery/meshery-consul'
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@master
-      - name: Set up Go
-        uses: actions/setup-go@master
-        with:
-          go-version: 1.23.x
-          cache: true
-          cache-dependency-path: go.sum
-      - name: Run unit tests
-        run: go test --short ./... -race -coverprofile=coverage.txt -covermode=atomic
-      - name: Upload coverage to Codecov
-        if: github.repository == 'meshery/meshery-consul'
-        uses: codecov/codecov-action@v2.1.0
-        with:
-          files: ./coverage.txt
-          flags: unittests
+  
   build:
     name: Build check
     runs-on: ubuntu-latest
-    needs: [codecov]
+    needs: [tidy]
     steps:
     - name: Check out code
       uses: actions/checkout@master


### PR DESCRIPTION
***Relation*
Part of organization-wide codecov removal effort.

**Notes for Reviewers**
**Removed** entire `codecov` job from `.github/workflows/ci.yml` (lines 38-61)
- **Updated** `build` job dependency from `needs: [codecov]` to `needs: [tidy]`
- **Workflow chain updated**: `lint → tidy → build` (previously: `lint → tidy → codecov → build`)
- **Coverage generation**: Can still be run locally using: `go test --short ./... -race -coverprofile=coverage.txt -covermode=atomic`

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.